### PR TITLE
feat: added maxlen option

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
     "rules": {
       "unicorn/prevent-abbreviations": "off",
       "capitalized-comments": "off",
-      "no-new": "off"
+      "no-new": "off",
+      "complexity": ["warn", 21]
     }
   },
   "clinton": {

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,11 @@ Default:
   Default: '\n'  
   Description: *As value is a string symbol which is added to the end of the file and will not adds if you specify a boolean value of `false`*
 
+  - **maxlen**  
+  Type: `Number`  
+  Default: '80'  
+  Description: *checks for the max length of the content, indents the whole content to a new line*
+
 ### `mini`
 Type: `Object`  
 Default:

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ const renderConditional = tree => {
   }, []);
 };
 
-const indent = (tree, {rules: {indent, eol, blankLines}}) => {
+const indent = (tree, {rules: {indent, eol, blankLines, maxlen}}) => {
   const setIndent = (tree, level = 0) => tree.reduce((previousValue, node, index) => {
     if (typeof node === 'object' && Object.prototype.hasOwnProperty.call(node, 'content')) {
       node.content = setIndent(node.content, ++level);
@@ -99,6 +99,12 @@ const indent = (tree, {rules: {indent, eol, blankLines}}) => {
     }
 
     if (tree.length === 1 && typeof tree[index] === 'string') {
+      if (tree[index].length >= maxlen) {
+        let l = level;
+        let e = l;
+        return [...previousValue, getIndent(l, {indent, eol}), node, getIndent(--e, {indent, eol})];
+      }
+
       return [...previousValue, node];
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -100,9 +100,7 @@ const indent = (tree, {rules: {indent, eol, blankLines, maxlen}}) => {
 
     if (tree.length === 1 && typeof tree[index] === 'string') {
       if (tree[index].length >= maxlen) {
-        let l = level;
-        let e = l;
-        return [...previousValue, getIndent(l, {indent, eol}), node, getIndent(--e, {indent, eol})];
+        return [...previousValue, getIndent(level, {indent, eol}), node, getIndent(--level, {indent, eol})];
       }
 
       return [...previousValue, node];

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,5 +1,6 @@
 export default {
   indent: 2,
+  maxlen: 80,
   blankLines: '\n',
   eof: '\n',
   eol: '\n'

--- a/test/test-plugin.js
+++ b/test/test-plugin.js
@@ -44,6 +44,24 @@ test('processing with plugin beautify should return equal html', async t => {
   t.deepEqual(fixture, (await processing(fixture, [beautify({rules: {eof: false}})])).html);
 });
 
+test('processing with plugin beautify should return allowed max line content', async t => {
+  const fixture = '<div>some long long content here to test max len</div>';
+  const expected = `<div>
+  some long long content here to test max len
+</div>`;
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {eof: false, maxlen: 10}})])).html);
+});
+
+test('processing with plugin beautify should return allowed max line content #2', async t => {
+  const fixture = '<div><a>some long long content here to test max len</a></div>';
+  const expected = `<div>
+  <a>
+    some long long content here to test max len
+  </a>
+</div>`;
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {eof: false, maxlen: 10}})])).html);
+});
+
 test('processing with plugin beautify should removing trailing slash in self-closing', async t => {
   const fixture = '<img src="image.jpg" />';
   const expected = '<img src="image.jpg">';


### PR DESCRIPTION
added a new option

**maxlen**  
 Type: `Number`  
 Default: '80'  
 Description: _checks for the max length of the content, indents the whole content to a new line_

**input**

```html
<div>some long long content here to test max len</div>
```

**Option**

```js
{rules: {eof: false, maxlen: 10}}
```

**output**

```html
<div>
  some long long content here to test max len
</div>
```