### PR TITLE
feat: language attribute support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Format your html and inline css markup according to the [HTML5 syntax Style Guid
 - [x] Removes spaces at the equal sign
 - [x] Add blank lines to separate large or logical code blocks
 - [x] Add 2 spaces of indentation. *Do not use TAB*.
-- [ ] Add language attribute
+- [x] Add language attribute
 - [ ] Add character encoding
 - [x] Attribute order
 - [x] Boolean attributes
@@ -89,6 +89,11 @@ Default:
   Type: `Boolean`  
   Default: false  
   Description: *Sort the order of attributes in elements*
+
+  - **lang**  
+  Type: `String | Boolean(only false)`  
+  Default: false  
+  Description: *Add a `lang` attribute in elements, eg: `{ lang: 'fr' }`*
 
 ### `mini`
 Type: `Object`  

--- a/src/index.js
+++ b/src/index.js
@@ -272,6 +272,22 @@ const jsPrettier = (tree, {rules: {indent, eol}, jsBeautifyOptions}) => {
   return prettier(tree);
 };
 
+const addLang = (tree, {rules: {lang}}) => {
+  if (!lang) {
+    return tree;
+  }
+
+  tree.map(node => {
+    if (node.tag) {
+      node.attrs = Object.assign({}, {lang}, node.attrs);
+    }
+
+    return node;
+  });
+
+  return tree;
+};
+
 const beautify = (tree, options) => [
   clean,
   parseConditional,
@@ -282,6 +298,7 @@ const beautify = (tree, options) => [
   lowerAttributeName,
   attributesBoolean,
   sortAttr,
+  addLang,
   eof,
   mini
 ].reduce((previousValue, module) => typeof module === 'function' ? module(previousValue, options) : previousValue, tree);

--- a/src/rules.js
+++ b/src/rules.js
@@ -4,5 +4,6 @@ export default {
   blankLines: '\n',
   eof: '\n',
   eol: '\n',
-  sortAttr: false
+  sortAttr: false,
+  lang: false
 };

--- a/test/test-plugin.js
+++ b/test/test-plugin.js
@@ -74,6 +74,12 @@ test('processing with plugin beautify sort the attribute list', async t => {
   t.deepEqual(expected, (await processing(fixture, [beautify({rules: {eof: false, sortAttr: true}})])).html);
 });
 
+test('processing with plugin beautify sort the attribute list wrapper', async t => {
+  const fixture = '<div a="aa" c="cc" b="bb"><p a="aa" c="cc" b="bb">a</p></div>';
+  const expected = '<div a="aa" b="bb" c="cc">\n  <p a="aa" b="bb" c="cc">a</p>\n</div>';
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {eof: false, sortAttr: true}})])).html);
+});
+
 test('processing with plugin beautify sort the attribute list example 2', async t => {
   const fixture = '<p a="aa" c b="bb">a</p>';
   const expected = '<p a="aa" b="bb" c="">a</p>';
@@ -168,6 +174,12 @@ test('processing with plugin beautify to add language attribute', async t => {
   t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
 });
 
+test('processing with plugin beautify to add language attribute with wrapper', async t => {
+  const fixture = '<div><p >a</p></div>';
+  const expected = '<div lang="en">\n  <p lang="en">a</p>\n</div>\n';
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
+});
+
 test('processing with plugin beautify to add language attribute with existing attr', async t => {
   const fixture = '<p data="e">a</p>';
   const expected = '<p lang="en" data="e">a</p>\n';
@@ -177,5 +189,11 @@ test('processing with plugin beautify to add language attribute with existing at
 test('processing with plugin beautify to add language attribute with existing lang attribute', async t => {
   const fixture = '<p lang="fr">a</p>';
   const expected = '<p lang="fr">a</p>\n';
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
+});
+
+test('processing with plugin beautify to add language attribute with existing lang attribute nested', async t => {
+  const fixture = '<div><p lang="fr">a</p></div>';
+  const expected = '<div lang="en">\n  <p lang="fr">a</p>\n</div>\n';
   t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
 });

--- a/test/test-plugin.js
+++ b/test/test-plugin.js
@@ -162,3 +162,20 @@ test('processing with plugin beautify should return format js', async t => {
   );
 });
 
+test('processing with plugin beautify to add language attribute', async t => {
+  const fixture = '<p >a</p>';
+  const expected = '<p lang="en">a</p>\n';
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
+});
+
+test('processing with plugin beautify to add language attribute with existing attr', async t => {
+  const fixture = '<p data="e">a</p>';
+  const expected = '<p lang="en" data="e">a</p>\n';
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
+});
+
+test('processing with plugin beautify to add language attribute with existing lang attribute', async t => {
+  const fixture = '<p lang="fr">a</p>';
+  const expected = '<p lang="fr">a</p>\n';
+  t.deepEqual(expected, (await processing(fixture, [beautify({rules: {lang: 'en'}})])).html);
+});


### PR DESCRIPTION
#### Before

```html
<p>hello</p>
<a lang="en"> yello </a>
```

#### Config

```js
{
  ...
  lang: "fr";
}
```

#### After

```html
<p lang="fr">hello</p>
<a lang="en"> yello </a>
```
